### PR TITLE
Update scala-xml 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val xtract = project.in(file("xtract-core")).settings(
   name := "xtract",
   description := "Library to deserialize Xml to user types.",
   libraryDependencies ++= Seq(
-    "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+    "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
     functionalDep(scalaVersion.value),
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ inThisBuild(Seq(
   organization := "com.lucidchart",
   scmInfo := Some(ScmInfo(url("https://github.com/lucidsoftware/xtract"), "scm:git:git@github.com:lucidsoftware/xtract.git")),
   version := sys.props.getOrElse("build.version", "0-SNAPSHOT"),
-  fork in test := true,
   useGpg := true,
   scalacOptions ++= Seq(
     "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.2


### PR DESCRIPTION
Version changes `XML.save` to UTF-8 from ISO-8859-1.  Otherwise, it's just a bug-fix release:

https://github.com/scala/scala-xml/releases/tag/v1.1.0

Update sbt to 1.1.2 while we're at it.  No longer requires `fork := true` hack to use scala-xml.
