### PR TITLE
Add Default XmlReader[Long]

### DIFF
--- a/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
+++ b/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
@@ -81,7 +81,7 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
   }
 
   "intReader" should {
-    "parse double from node" in {
+    "parse int from node" in {
       intReader.read(<xml>22</xml>) must beParseSuccess(22)
     }
 
@@ -99,6 +99,31 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
 
     "give multiple matches error for multiple matches" in {
       intReader.read(multiple) must beParseFailure(Seq(
+        MultipleMatchesError()
+      ))
+    }
+  }
+
+  "longReader" should {
+    "parse long from node" in {
+      longReader.read(<xml>22</xml>) must beParseSuccess(22L)
+      longReader.read(<xml>5000000000</xml>) must beParseSuccess(5000000000L)
+    }
+
+    "give type error for bad format" in {
+      longReader.read(<xml>abc</xml>) must beParseFailure(Seq(
+        TypeError(Long.getClass)
+      ))
+    }
+
+    "give empty error for missing node" in {
+      longReader.read(empty) must beParseFailure(Seq(
+        EmptyError()
+      ))
+    }
+
+    "give multiple matches error for multiple matches" in {
+      longReader.read(multiple) must beParseFailure(Seq(
         MultipleMatchesError()
       ))
     }

--- a/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
+++ b/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
@@ -56,6 +56,19 @@ trait DefaultXmlReaders {
   }
 
   /**
+   * [[XmlReader]] that gets the text of a single node as a long
+   */
+  implicit val longReader: XmlReader[Long] = XmlReader { xml =>
+    getNode(xml).flatMap { node =>
+      try {
+        ParseSuccess(node.text.toLong)
+      } catch {
+        case _: NumberFormatException => ParseFailure(TypeError(Long.getClass))
+      }
+    }
+  }
+
+  /**
    *  [[XmlReader]] that gets the text of a single node as a boolean
    */
   implicit val booleanReader: XmlReader[Boolean] = XmlReader { xml =>


### PR DESCRIPTION
re: https://github.com/lucidsoftware/xtract/issues/20

I did my best to follow the code style, but let me know if there's something that should be changed. I also noticed the `intReader` spec was labeled "parse double", and changed it to "parse int".

Thanks,
Joe