### PR TITLE
Parsing support for Int and Long with extra spaces before and after actual number

### DIFF
--- a/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
+++ b/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
@@ -85,8 +85,20 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
       intReader.read(<xml>22</xml>) must beParseSuccess(22)
     }
 
-    "give type error for bad format" in {
+    "parse int from node with extra spaces" in {
+      intReader.read(<xml>
+        22
+      </xml>) must beParseSuccess(22)
+    }
+
+    "give type error for non-numbers" in {
       intReader.read(<xml>abc</xml>) must beParseFailure(Seq(
+        TypeError(Int.getClass)
+      ))
+    }
+
+    "give type error for numbers mixed with non-space characters" in {
+      intReader.read(<xml>abc12ef</xml>) must beParseFailure(Seq(
         TypeError(Int.getClass)
       ))
     }
@@ -110,8 +122,23 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
       longReader.read(<xml>5000000000</xml>) must beParseSuccess(5000000000L)
     }
 
-    "give type error for bad format" in {
+    "parse long from node with extra spaces" in {
+      longReader.read(<xml>
+        22
+        </xml>) must beParseSuccess(22L)
+      longReader.read(<xml>
+        5000000000
+        </xml>) must beParseSuccess(5000000000L)
+    }
+
+    "give type error for non-numbers" in {
       longReader.read(<xml>abc</xml>) must beParseFailure(Seq(
+        TypeError(Long.getClass)
+      ))
+    }
+
+    "give type error for numbers mixed with non-space characters" in {
+      longReader.read(<xml>abc12ef</xml>) must beParseFailure(Seq(
         TypeError(Long.getClass)
       ))
     }

--- a/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
+++ b/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
@@ -48,7 +48,7 @@ trait DefaultXmlReaders {
   implicit val intReader: XmlReader[Int] = XmlReader { xml =>
     getNode(xml).flatMap { node =>
       try {
-        ParseSuccess(node.text.toInt)
+        ParseSuccess(node.text.trim.toInt)
       } catch {
         case _: NumberFormatException => ParseFailure(TypeError(Int.getClass))
       }
@@ -61,7 +61,7 @@ trait DefaultXmlReaders {
   implicit val longReader: XmlReader[Long] = XmlReader { xml =>
     getNode(xml).flatMap { node =>
       try {
-        ParseSuccess(node.text.toLong)
+        ParseSuccess(node.text.trim.toLong)
       } catch {
         case _: NumberFormatException => ParseFailure(TypeError(Long.getClass))
       }


### PR DESCRIPTION
The problem is Scala can't parse Int and/or Long numbers from strings with extra spaces.
For example
`"12".toInt` will parse 12 successfully but
`"     12     ".toInt` will throw NumberFormatException.

That could be a problem when XML is not quite well formed and tags with numeric value could contain new-line characters, spaces, etc.