### PR TITLE
spaceDelimitedArray reader improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea/
 
 /pages

--- a/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
+++ b/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
@@ -186,6 +186,36 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
     }
   }
 
+  "spaceDelimitedArrayReader" should {
+    "parse array from node" in {
+      spaceDelimitedArray.read(<xml>a b c</xml>) must beParseSuccess(Array[String]("a", "b", "c"))
+    }
+
+    "parse array from node with extra spaces" in {
+      spaceDelimitedArray.read(<xml> a
+        b c
+      </xml>) must beParseSuccess(Array[String]("a", "b", "c"))
+    }
+
+    "parse array from node with one value" in {
+      spaceDelimitedArray.read(<xml>a</xml>) must beParseSuccess(Array[String]("a"))
+    }
+
+    "parse array from node with one value and extra spaces" in {
+      spaceDelimitedArray.read(<xml>
+        a
+        </xml>) must beParseSuccess(Array[String]("a"))
+    }
+
+    "parse empty array from node with no values" in {
+      spaceDelimitedArray.read(<xml></xml>) must beParseSuccess(Array.empty[String])
+    }
+
+    "parse empty array from node with only spaces as a value" in {
+      spaceDelimitedArray.read(<xml>      </xml>) must beParseSuccess(Array.empty[String])
+    }
+  }
+
   "label" should {
     "be failure when empty xml" in {
       label("blah")(pure(23)).read(empty) must beParseFailure(Seq(
@@ -235,7 +265,6 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
   }
 
   "at" should {
-
     "pass xml to path" in {
       val mockXPath = mock[XPath]
       mockXPath.apply(any[NodeSeq]) returns <xml></xml>
@@ -289,7 +318,6 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
   }
 
   "seq" should {
-
     "parse an empty element gives Nil" in {
       seq(pure(1)).read(empty) must beParseSuccess({ result: Seq[Int] =>
         result must beEmpty

--- a/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
+++ b/unit-tests/src/test/scala/com/lucidchart/open/xtract/DefaultXmlReadersSpec.scala
@@ -157,8 +157,14 @@ class DefaultXmlReadersSpec extends XmlReaderSpecification with DefaultXmlReader
   }
 
   "booleanReader" should {
-    "parse double from node" in {
+    "parse boolean from node" in {
       booleanReader.read(<xml>false</xml>) must beParseSuccess(false)
+    }
+
+    "parse boolean from node with extra spaces" in {
+      booleanReader.read(<xml>
+        false
+        </xml>) must beParseSuccess(false)
     }
 
     "give type error for bad format" in {

--- a/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
+++ b/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
@@ -180,7 +180,7 @@ trait DefaultXmlReaders {
    * An [[XmlReader]] for extracting space delimited lists of values as an Array of strings.
    */
   val spaceDelimitedArray: XmlReader[Array[String]] = XmlReader { xml =>
-    ParseSuccess(xml.text.split("\\s+"))
+    ParseSuccess(xml.text.split("\\s+").filter(_.nonEmpty))
   }
 
   private def addPath(path: XPath, parseError: ParseError): ParseError = {

--- a/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
+++ b/xtract-core/src/main/scala/com/lucidchart/open/xtract/DefaultXmlReaders.scala
@@ -74,7 +74,7 @@ trait DefaultXmlReaders {
   implicit val booleanReader: XmlReader[Boolean] = XmlReader { xml =>
     getNode(xml).flatMap { node =>
       try {
-        ParseSuccess(node.text.toBoolean)
+        ParseSuccess(node.text.trim.toBoolean)
       } catch {
         case _: IllegalArgumentException => ParseFailure(TypeError(Boolean.getClass))
       }


### PR DESCRIPTION
It is annoying to always filter out empty strings from spaceDelimitedArray reader output.
For example `spaceDelimitedArray.read(<xml> a b c </xml>)` return `Array("", "a", "b", "c")`.
The first empty string in result array is obviously superfluous.